### PR TITLE
Add rotation support for iPads

### DIFF
--- a/AppData/Classes/Controller/ADDataViewController.m
+++ b/AppData/Classes/Controller/ADDataViewController.m
@@ -188,8 +188,20 @@
     [self dismissViewControllerAnimated:animated completion:completion];
 }
 
+- (BOOL)shouldAutorotate {
+    if (IS_IPAD) {
+        return YES;
+    } else {
+        return NO;
+    }
+}
+
 - (UIInterfaceOrientationMask)supportedInterfaceOrientations {
-    return UIInterfaceOrientationMaskPortrait;
+    if (IS_IPAD) {
+        return UIInterfaceOrientationMaskAll;
+    } else {
+        return UIInterfaceOrientationMaskPortrait;
+    }
 }
 
 - (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldReceiveTouch:(UITouch *)touch {


### PR DESCRIPTION
This PR aims to add support for the rotation of the AppData modal on iPads with this tweak installed.

Currently, the displayed window forces itself to be displayed in portrait orientation, even when the device is in landscape or upside-down portrait orientation on the home screen. This PR hopes to fix that by making the following changes to the ADDataViewController implementation:
- conditionally including the shouldAutoRotate property for iPad devices
- conditionally modifying the orientation mask to include all orientations for iPad devices